### PR TITLE
Port 1.21.11

### DIFF
--- a/build.fabric.gradle.kts
+++ b/build.fabric.gradle.kts
@@ -62,6 +62,12 @@ java {
     targetCompatibility = javaCompat
 }
 
+stonecutter {
+    replacements.string(eval(current.version, ">=1.21.11")) {
+        replace("ResourceLocation", "Identifier")
+    }
+}
+
 val supportedMinecraftVersions: List<String> = com.google.common.collect.ImmutableList.builder<String>()
     .addAll(
         (property("publish.additionalVersions") as String?)

--- a/build.neoforge.gradle.kts
+++ b/build.neoforge.gradle.kts
@@ -72,6 +72,12 @@ java {
     targetCompatibility = javaCompat
 }
 
+stonecutter {
+    replacements.string(eval(current.version, ">=1.21.11")) {
+        replace("ResourceLocation", "Identifier")
+    }
+}
+
 val supportedMinecraftVersions: List<String> = com.google.common.collect.ImmutableList.builder<String>()
     .addAll(
         (property("publish.additionalVersions") as String?)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ stonecutter {
         match("1.21.3", "neoforge")
         match("1.21.8", "fabric")
         match("1.21.10", "fabric", "neoforge")
+        match("1.21.11", "fabric", "neoforge")
 
         vcsVersion = "1.21.10-fabric"
     }

--- a/src/main/java/com/iafenvoy/server/i18n/ServerI18nReloader.java
+++ b/src/main/java/com/iafenvoy/server/i18n/ServerI18nReloader.java
@@ -8,6 +8,8 @@ import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 
+import java.io.Reader;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -15,32 +17,51 @@ public enum ServerI18nReloader implements ResourceManagerReloadListener {
     INSTANCE;
     public static final ResourceLocation ID = /*? >=1.21 {*/ResourceLocation.fromNamespaceAndPath/*?} else {*//*new ResourceLocation*//*?}*/(ServerI18nApi.MOD_ID, ServerI18nApi.MOD_ID);
     public static final String DEFAULT_LANGUAGE = "en_us";
-    private static final Map<String, Map<String, String>> DATA = new HashMap<>();
+    private static volatile Map<String, Map<String, String>> DATA = Collections.emptyMap();
 
     @Override
     public void onResourceManagerReload(ResourceManager manager) {
-        DATA.clear();
+        final Map<String, Map<String, String>> pendingData = new HashMap<>();
         for (Map.Entry<ResourceLocation, Resource> entry : manager.listResources("lang", p -> p.getPath().endsWith(".json")).entrySet()) {
-            String language = entry.getKey().getPath().replaceAll(".json", "").replaceAll("lang/", "");
-            if (!DATA.containsKey(language)) DATA.put(language, new HashMap<>());
-            Map<String, String> map = DATA.get(language);
+            String language = removeSurrounding(entry.getKey().getPath());
+
+            Map<String, String> map = pendingData.computeIfAbsent(language, k -> new HashMap<>());
             try {
-                JsonElement element = JsonParser.parseReader(entry.getValue().openAsReader());
+                JsonElement element;
+                try (Reader reader = entry.getValue().openAsReader()) {
+                    element = JsonParser.parseReader(reader);
+                }
                 if (!element.isJsonObject()) continue;
                 JsonObject obj = element.getAsJsonObject();
-                for (String s : obj.keySet()) map.put(s, obj.get(s).getAsString());
+                obj.asMap().forEach((key, value) -> {
+                    if (!value.isJsonPrimitive()) return;
+                    map.put(key, value.getAsString());
+                });
             } catch (Exception e) {
                 ServerI18nApi.LOGGER.error("Failed to load {}", entry.getKey().toString(), e);
             }
         }
+        DATA = Collections.unmodifiableMap(pendingData);
+    }
+
+    private static String removeSurrounding(String s) {
+        int startIndex = 0, endIndex = s.length();
+        if (s.startsWith("lang/")) startIndex = "lang/".length();
+        if (s.endsWith(".json")) endIndex -= ".json".length();
+
+        if (startIndex > endIndex) return "";   // does not happen
+        return s.substring(startIndex, endIndex);
     }
 
     public static String translate(String language, String key) {
-        if (DATA.containsKey(language)) {
-            Map<String, String> map = DATA.get(language);
-            if (map.containsKey(key)) return DATA.get(language).get(key);
+        String value = null;
+        Map<String, String> map;
+        if ((map = DATA.get(language)) != null) {
+            value = map.get(key);
         }
-        if (DATA.containsKey(DEFAULT_LANGUAGE)) return DATA.get(DEFAULT_LANGUAGE).getOrDefault(key, key);
-        return key;
+        if (value == null && (map = DATA.get(DEFAULT_LANGUAGE)) != null) {
+            value = map.get(key);
+        }
+        return value != null ? value : key;
     }
 }

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("dev.kikugie.stonecutter")
     id("co.uzzu.dotenv.gradle") version "4.0.0"
-    id("fabric-loom") version "1.11-SNAPSHOT" apply false
+    id("fabric-loom") version "1.13-SNAPSHOT" apply false
     id("net.neoforged.moddev") version "2.0.115" apply false
     id("dev.kikugie.postprocess.jsonlang") version "2.1-beta.4" apply false
     id("me.modmuss50.mod-publish-plugin") version "0.8.+" apply false

--- a/versions/1.21.11-fabric/gradle.properties
+++ b/versions/1.21.11-fabric/gradle.properties
@@ -1,0 +1,4 @@
+deps.minecraft=1.21.11
+deps.fabric-api=0.141.4+1.21.11
+deps.parchment=1.21.11:2025.12.20
+publish.additionalVersions=

--- a/versions/1.21.11-neoforge/gradle.properties
+++ b/versions/1.21.11-neoforge/gradle.properties
@@ -1,0 +1,4 @@
+deps.minecraft=1.21.11
+deps.neoforge=21.11.42
+deps.parchment=1.21.11:2025.12.20
+publish.additionalVersions=


### PR DESCRIPTION
This PR contains:
- Port for 1.21.11-fabric and 1.21.11-neoforge (implemented using `stonecutter.replacements`)
- Optimizations for `ServerI18nReloader`.

For 26.1 and newer versions, I'm about to create a fork *without* stonecutter, since I'm not sure if it works on unobfuscated versions. I personally prefer all-in-one JARs for these versions (e.g. [my Remote Resource Pack mod](https://modrinth.com/mod/remote-resource-pack/version/2.2.5+26.1-universal)), which simply uses [Shadow](https://plugins.gradle.org/plugin/com.gradleup.shadow).